### PR TITLE
provide convenient navbar links to User Guide and GitHub source code

### DIFF
--- a/templates/tom_common/navbar_content.html
+++ b/templates/tom_common/navbar_content.html
@@ -54,5 +54,16 @@ The following nav-item list elements (li) are included in the tom_common/base.ht
 <li class="nav-item {% if 'user' in request.resolver_match.url_name %}active{% endif %}">
     <a class="nav-link" href="{% url 'calibrations:flat_home' %}">Flat</a>
 </li>
+<li class="nav-item dropdown">
+    <a class="nav-link dropdown-toggle" data-toggle="dropdown">Documentation</a>
+    <ul class="dropdown-menu">
+        <li class="nav-item active">
+            <a class="nav-link" href="https://docs.google.com/document/d/1dpfSSYDeRUz4Rlnxck8wuRIp54A47JS3IO8-DX-sGGk/" style="color:black">User Guide</a>
+        </li>
+        <li class="nav-item active">
+            <a class="nav-link" href="https://github.com/LCOGT/calibration-tom" style="color:black">Source Code</a>
+        </li>
+    </ul>
+</li>
 
 


### PR DESCRIPTION
check it out working in [calibration-tom-dev](http://calibration-tom-dev.lco.gtn)
Is there a better way to provide the external hrefs rather than literally?