### PR TITLE
Feature/more nres home tweaks

### DIFF
--- a/targeted_calibrations/templates/targeted_calibrations/partials/nres_cadence_list.html
+++ b/targeted_calibrations/templates/targeted_calibrations/partials/nres_cadence_list.html
@@ -15,7 +15,7 @@
     {% for cadence_data in cadences_data %}
     <tr>
         <td>{{ cadence_data.cadence.cadence_parameters.site }}</td>
-        <td>TBD</td>
+        <td>{{ cadence_data.standard_type }}</td>
         <td>{{ cadence_data.cadence.cadence_parameters.cadence_frequency }}</td>
         {% if cadence_data.prev_obs %}
             <td>

--- a/targeted_calibrations/templatetags/targeted_calibrations_extras.py
+++ b/targeted_calibrations/templatetags/targeted_calibrations_extras.py
@@ -40,12 +40,12 @@ def nres_cadence_list():
     # Annotate Dynamic Cadences with site and calibration type in order to sort by JSONField values
     nres_cadences = (DynamicCadence.objects.filter(cadence_strategy='NRESCadenceStrategy')
                      .annotate(site=Cast(KeyTextTransform('site', 'cadence_parameters'), models.TextField()))
-                     .annotate(standard_type=Cast(KeyTextTransform('standard_type', 'cadence_parameters'),
-                                                  models.TextField()))  # TODO: This should be the standard type
+                     .annotate(target_id=Cast(KeyTextTransform('target_id', 'cadence_parameters'), models.TextField()))
                      .order_by('-created')
                      .order_by('site'))
     context = {'cadences_data': [{
         'cadence': cadence,
+        'standard_type': Target.objects.filter(pk=cadence.target_id).first().targetextra_set.filter(key='standard_type').first().value,
         'prev_obs': cadence.observation_group.observation_records.filter(status='COMPLETED').order_by('-scheduled_end').first(),
         'next_obs': cadence.observation_group.observation_records.filter(status='PENDING').order_by('scheduled_start').first()
     } for cadence in nres_cadences]}

--- a/targeted_calibrations/templatetags/targeted_calibrations_extras.py
+++ b/targeted_calibrations/templatetags/targeted_calibrations_extras.py
@@ -41,8 +41,7 @@ def nres_cadence_list():
     nres_cadences = (DynamicCadence.objects.filter(cadence_strategy='NRESCadenceStrategy')
                      .annotate(site=Cast(KeyTextTransform('site', 'cadence_parameters'), models.TextField()))
                      .annotate(target_id=Cast(KeyTextTransform('target_id', 'cadence_parameters'), models.TextField()))
-                     .order_by('-created')
-                     .order_by('site'))
+                     .order_by('site', '-created'))
     context = {'cadences_data': [{
         'cadence': cadence,
         'standard_type': Target.objects.filter(pk=cadence.target_id).first().targetextra_set.filter(key='standard_type').first().value,


### PR DESCRIPTION
Fixes re-ordering problem upon play/pause and adds standard type to cadence list. One question, I had was how the `target_id` is annotated onto the `nres_cadences` QuerySet: I wonder if `Cast(KeyTextTransform(....), model.TextField())` for the `target_id` falls into the works-but-silly category. Is there a better way to do this with a <pk> ?