### PR TITLE
Fix/ingress v1.22

### DIFF
--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: calibration-tom
-version: 0.1.0
+version: 0.2.0

--- a/helm-chart/templates/ingress.yaml
+++ b/helm-chart/templates/ingress.yaml
@@ -1,11 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "calibration-tom.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
-{{- else -}}
-apiVersion: extensions/v1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -33,9 +29,12 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
         {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
This updates the ingress spec for the calibration-tom to use networking.k8s.io/v1 which is compliant with k8s v1.22

I verified the correctness via:

```
helm template helm-chart -f helm-chart/values-prod.yaml | kubeval --kubernetes-version 1.22.1 --schema-location https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master
PASS - calibration-tom/templates/serviceaccount.yaml contains a valid ServiceAccount (RELEASE-NAME-calibration-tom)
PASS - calibration-tom/templates/service.yaml contains a valid Service (RELEASE-NAME-calibration-tom)
PASS - calibration-tom/templates/deployment.yaml contains a valid Deployment (RELEASE-NAME-calibration-tom)
PASS - calibration-tom/templates/crontab-crontrigger.yaml contains a valid CronJob (RELEASE-NAME-calibration-tom-crontrigger)
PASS - calibration-tom/templates/crontab-importinstruments.yaml contains a valid CronJob (RELEASE-NAME-calibration-tom-importinstruments)
PASS - calibration-tom/templates/crontab-runcadencestrategies.yaml contains a valid CronJob (RELEASE-NAME-calibration-tom-runcadencestrategies)
PASS - calibration-tom/templates/crontab-updatestatus.yaml contains a valid CronJob (RELEASE-NAME-calibration-tom-updatestatus)
PASS - calibration-tom/templates/ingress.yaml contains a valid Ingress (RELEASE-NAME-calibration-tom)
PASS - calibration-tom/templates/tests/test-connection.yaml contains a valid Pod (RELEASE-NAME-calibration-tom-test-connection)
```