### PR TITLE
Three filters for every standard observation.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # TODO: switch to setup.py so test requirements can be separated
 deprecation~=2.1
 #tomtoolkit~=2.14
-tomtoolkit==2.14.5alpha
+tomtoolkit<3
 crispy-bootstrap4
 psycopg2-binary~=2.9
 gunicorn[gevent]==20.0.4


### PR DESCRIPTION
Increase number of filters for photometric standard observation from 2 to 3. AFAIK, the number of filters is not checked/tested anywhere.

The next step (i.e. separate PR) will be to select specific sets of filters: UBV, ,BVR, VRI, ugr, gri.